### PR TITLE
Allow perl-5.8.1

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -31,11 +31,11 @@ x_irc = irc://irc.perl.org/#win32
 [FileFinder::ByName / NoOSMods]
 dir   = lib
 match = Process(Table)?\.pm
-  
+
 [PodWeaver]
 finder = NoOSMods
 
 [@Prereqs]
 finder = NoOSMods
 skip = ^P9Y::ProcessTable
-minimum_perl = 5.10.1
+minimum_perl = 5.8.8

--- a/inc/P9YOSDeps.pm
+++ b/inc/P9YOSDeps.pm
@@ -3,13 +3,13 @@ use Moose;
 
 extends 'Dist::Zilla::Plugin::MakeMaker::Awesome';
 
-override _build_WriteMakefile_args => sub { 
+override _build_WriteMakefile_args => sub {
    shift->zilla->distmeta->{dynamic_config} = 1;
    +{
       %{ super() },
    }
 };
- 
+
 override _build_WriteMakefile_dump => sub {
    my ($self) = @_;
    my $txt = super();
@@ -21,49 +21,54 @@ override _build_WriteMakefile_dump => sub {
 override _build_MakeFile_PL_template => sub {
     my ($self) = @_;
     my $template = super();
- 
+
     $template .= <<'TEMPLATE';
-use v5.10;    
+use v5.8.8;
 
 sub os_deps {
-   for (lc $^O) {
-      when (/mswin32|cygwin/) {
-         return (
+    my $_os = lc($^O);
+
+    if ( $_os =~ /mswin32|cygwin/ ) {
+      return (
             'Win32::Process'       => 0,
             'Win32::Process::Info' => 0,
-         );
-      }
-      when ('freebsd') {
-         return ('BSD::Process' => 0);
-      }
-      when ('darwin') {
-         return ('Proc::ProcessTable' => 0.45);
-      }
-      when ('os2') {
-         return ('OS2::Process' => 0);
-      }
-      when ('vms') {
-         return ('VMS::Process' => 0);
-      }
-      when ('dos') {
-         die "Heh, DOS processes... you're funny!";
-      }
-      default {
-         # let's hope they have /proc
-         unless ( -d '/proc' ) {
-            die lc $^O =~ /bsd|dragonfly/ ? 
-               "BSD::Process only works for FreeBSD.  Encourage development for $^O, or write your own and I can include it here." :
-               "No idea how to handle $^O processes.  Email me with more information!";
-         }
-      }
-   }
-   return ();
+        );
+    }
+    elsif ( $_os eq 'freebsd' ) {
+      return ( 'BSD::Process' => 0 );
+    }
+    elsif ( $_os eq 'darwin' ) {
+      return ( 'Proc::ProcessTable' => 0.45 );
+    }
+    elsif ( $_os eq 'os2' ) {
+      return ( 'OS2::Process' => 0 );
+    }
+    elsif ( $_os eq 'vms' ) {
+      return ( 'VMS::Process' => 0 );
+    }
+    elsif ( $_os eq 'dos' ) {
+        die "Heh, DOS processes... you're funny!";
+    }
+    else {
+        # let's hope they have /proc
+        if ( not -d '/proc' ) {
+            if ( $_os =~ /bsd|dragonfly/ ) {
+                die "BSD::Process only works for FreeBSD."
+                  . " Encourage development for $_os, or write your own and I can include it here.";
+            }
+            else {
+                die "No idea how to handle $_os processes."
+                  . " Email me with more information!";
+            }
+        }
+    }
+  return ();
 }
 TEMPLATE
- 
+
     return $template;
 };
-   
+
 __PACKAGE__->meta->make_immutable;
 
 42;

--- a/lib/P9Y/ProcessTable.pm
+++ b/lib/P9Y/ProcessTable.pm
@@ -3,44 +3,51 @@ package P9Y::ProcessTable;
 # VERSION
 # ABSTRACT: Portably access the process table
 
-use sanity;
+# use sanity;
+use utf8;
+use strict qw(subs vars);
+no strict 'refs';
+use warnings FATAL => 'all';
+no warnings qw(uninitialized);
 
 use Path::Class;
 use namespace::clean;
 
 BEGIN {
-   # Figure out which OS module we should use
-   for (lc $^O) {
-      when (/mswin32|cygwin/) {
-         require P9Y::ProcessTable::Win32;
-      }
-      # BSD::Process currently only supports FreeBSD;
-      # fall by on /proc for the others
-      when ('freebsd') {
-         require P9Y::ProcessTable::BSD;
-      }
-      when ('darwin') {
-         require P9Y::ProcessTable::Darwin;
-      }
-      when ('os2') {
-         require P9Y::ProcessTable::OS2;
-      }
-      when ('vms') {
-         require P9Y::ProcessTable::VMS;
-      }
-      when ('dos') {
-         die "Heh, DOS processes... you're funny!";
-      }
-      default {
-         # let's hope they have /proc
-         if ( -d dir('', 'proc') ) {
+
+    # Figure out which OS module we should use
+    my $_os = lc($^O);
+    if ( $_os =~ /mswin32|cygwin/ ) {
+        require P9Y::ProcessTable::Win32;
+    }
+    elsif ( $_os eq 'freebsd' ) {
+
+        # BSD::Process currently only supports FreeBSD;
+        # fall by on /proc for the others
+        require P9Y::ProcessTable::BSD;
+    }
+    elsif ( $_os eq 'darwin' ) {
+        require P9Y::ProcessTable::Darwin;
+    }
+    elsif ( $_os eq 'os2' ) {
+        require P9Y::ProcessTable::OS2;
+    }
+    elsif ( $_os eq 'vms' ) {
+        require P9Y::ProcessTable::VMS;
+    }
+    elsif ( $_os eq 'dos' ) {
+        die "Heh, DOS processes... you're funny!";
+    }
+    else {
+        # let's hope they have /proc
+        if ( -d dir( '', 'proc' ) ) {
             require P9Y::ProcessTable::ProcFS;
-         }
-         else {
-            die "No idea how to handle $^O processes.  Email me with more information!";
-         }
-      }
-   }
+        }
+        else {
+            die "No idea how to handle $_os processes."
+              . " Email me with more information!";
+        }
+    }
 }
 
 #############################################################################

--- a/lib/P9Y/ProcessTable/BSD.pm
+++ b/lib/P9Y/ProcessTable/BSD.pm
@@ -6,7 +6,13 @@ package  # hide from PAUSE
 #############################################################################
 # Modules
 
-use sanity;
+# use sanity;
+use utf8;
+use strict qw(subs vars);
+no strict 'refs';
+use warnings FATAL => 'all';
+no warnings qw(uninitialized);
+
 use Moo;
 use P9Y::ProcessTable::Process;
 
@@ -40,7 +46,7 @@ sub _process_hash {
    my $hash = {};
 
    # (only has the ones that are different)
-   state $stat_loc = { qw/
+   my $stat_loc = { qw/
       uid         ruid
       gid         rgid
       euid        uid
@@ -70,7 +76,7 @@ sub _process_hash {
    $hash->{ ttlflt} = $hash->{ minflt} + $hash->{ majflt};
    $hash->{cttlflt} = $hash->{cminflt} + $hash->{cmajflt};
 
-   state $states = {
+   my $states = {
       stat_1 => 'forking',
       stat_2 => 'run',
       stat_3 => 'sleep',

--- a/lib/P9Y/ProcessTable/Darwin.pm
+++ b/lib/P9Y/ProcessTable/Darwin.pm
@@ -6,7 +6,13 @@ package  # hide from PAUSE
 #############################################################################
 # Modules
 
-use sanity;
+# use sanity;
+use utf8;
+use strict qw(subs vars);
+no strict 'refs';
+use warnings FATAL => 'all';
+no warnings qw(uninitialized);
+
 use Moo;
 use P9Y::ProcessTable::Process;
 
@@ -28,7 +34,7 @@ no warnings 'redefine';
 
 sub table {
    my $self = shift;
-   return map { 
+   return map {
       my $hash = $self->_convert_hash($_);
       $hash->{_pt_obj} = $self;
       P9Y::ProcessTable::Process->new($hash);
@@ -43,7 +49,7 @@ sub list {
 sub fields {
    return ( qw/
       pid uid gid euid egid suid sgid ppid pgrp sess
-      cmdline 
+      cmdline
       utime stime start time
       priority fname state ttynum ttydev flags size rss wchan cpuid pctcpu pctmem
    / );
@@ -59,20 +65,20 @@ sub _process_hash {
 sub _convert_hash {
    my ($self, $info) = @_;
    return unless $info;
-   
+
    my $hash = {};
    # (only has the ones that are different)
-   state $stat_loc = { qw/
+   my $stat_loc = { qw/
       cmdline   cmndline
    / };
-   
+
    no strict 'refs';
    foreach my $key ( $self->fields ) {
       my $old = $stat_loc->{$key} || $key;
       my $item = $info->$old();
       $hash->{$key} = $item if defined $item;
    }
-   
+
    return $hash;
 }
 

--- a/lib/P9Y/ProcessTable/OS2.pm
+++ b/lib/P9Y/ProcessTable/OS2.pm
@@ -6,7 +6,13 @@ package  # hide from PAUSE
 #############################################################################
 # Modules
 
-use sanity;
+# use sanity;
+use utf8;
+use strict qw(subs vars);
+no strict 'refs';
+use warnings FATAL => 'all';
+no warnings qw(uninitialized);
+
 use Moo;
 use P9Y::ProcessTable::Process;
 
@@ -22,7 +28,7 @@ no warnings 'redefine';
 
 sub table {
    my $self = shift;
-   return map { 
+   return map {
       my $hash = $self->_convert_hash($_);
       $hash->{_pt_obj} = $self;
       P9Y::ProcessTable::Process->new($hash);
@@ -50,21 +56,21 @@ sub _process_hash {
 sub _convert_hash {
    my ($self, $info) = @_;
    return unless $info;
-   
+
    my $hash = {};
-   state $stat_loc = { qw/
+   my $stat_loc = { qw/
       pid        owner_pid
       sess       owner_sid
       cmdline    title
    / };
-   
+
    foreach my $key (keys %$stat_loc) {
       my $item = $info->{ $stat_loc->{$key} };
       $hash->{$key} = $item if defined $item;
    }
-      
+
    $hash->{ppid} = ppidOf($hash->{pid});
-   
+
    return $hash;
 }
 

--- a/lib/P9Y/ProcessTable/ProcFS.pm
+++ b/lib/P9Y/ProcessTable/ProcFS.pm
@@ -6,7 +6,13 @@ package  # hide from PAUSE
 #############################################################################
 # Modules
 
-use sanity;
+# use sanity;
+use utf8;
+use strict qw(subs vars);
+no strict 'refs';
+use warnings FATAL => 'all';
+no warnings qw(uninitialized);
+
 use Moo;
 use P9Y::ProcessTable::Process;
 
@@ -97,7 +103,7 @@ sub _process_hash {
       my $data = $pdir->file('stat')->slurp;
       my @data = split /\s+/, $data;
 
-      state $states = {
+      my $states = {
          R => 'run',
          S => 'sleep',
          D => 'disk sleep',
@@ -106,7 +112,7 @@ sub _process_hash {
          W => 'paging',
       };
 
-      state $stat_loc = [ qw(
+      my $stat_loc = [ qw(
          pid fname state ppid pgrp sess ttynum . flags minflt cminflt majflt cmajflt utime stime cutime cstime priority . threads . .
          size . rss . . . . . . . . . wchan . . . cpuid . . . . .
       ) ];
@@ -160,7 +166,7 @@ sub _process_hash {
             splice @data, 2, 0, (0);
          }
 
-         state $stat_loc = [ qw(
+         my $stat_loc = [ qw(
             flags threads . pid ppid pgrp sess . . . . . . . utime . stime . cutime . cstime .
          ) ];
 
@@ -212,7 +218,7 @@ sub _process_hash {
             splice @data, 2, 0, (0);
          }
 
-         state $psinfo_loc = [ qw(
+         my $psinfo_loc = [ qw(
             . threads . pid ppid pgrp sess uid euid gid egid . size rss ttynum pctcpu pctmem start time ctime fname cmdline .
          ) ];
 
@@ -233,7 +239,7 @@ sub _process_hash {
       my $data = $pdir->file('status')->slurp;
       my @data = split /\s+/, $data;
 
-      state $stat_loc = [ qw(
+      my $stat_loc = [ qw(
          fname pid ppid pgrp sess ttynum flags start utime stime state euid
       ) ];
 

--- a/lib/P9Y/ProcessTable/Process.pm
+++ b/lib/P9Y/ProcessTable/Process.pm
@@ -6,7 +6,13 @@ package P9Y::ProcessTable::Process;
 #############################################################################
 # Modules
 
-use sanity;
+# use sanity;
+use utf8;
+use strict qw(subs vars);
+no strict 'refs';
+use warnings FATAL => 'all';
+no warnings qw(uninitialized);
+
 use Moo;
 
 use namespace::clean;
@@ -18,7 +24,7 @@ no warnings 'uninitialized';
 has _pt_obj  => (
    is       => 'ro',
    required => 1,
-   handles  => [qw( 
+   handles  => [qw(
       fields
       _process_hash
    )],
@@ -103,7 +109,7 @@ sub kill {
 sub pgrp {
    my ($self, $pgrp) = @_;
    return $self->{pgrp} if @_ == 1;
-   
+
    setpgrp($self->pid, $pgrp);
    $self->_set_pgrp($pgrp);
 }
@@ -111,7 +117,7 @@ sub pgrp {
 sub priority {
    my ($self, $pri) = @_;
    return $self->{priority} if @_ == 1;
-   
+
    setpriority(0, $self->pid, $pri);
    $self->_set_priority($pri);
 }
@@ -123,7 +129,7 @@ __END__
 =begin wikidoc
 
 = SYNOPSIS
- 
+
    use P9Y::ProcessTable;
 
    my $p = P9Y::ProcessTable->process;
@@ -131,7 +137,7 @@ __END__
       my $has_f = 'has_'.$f;
       print $f, ":  ", $p->$f(), "\n" if ( $p->$has_f() );
    }
- 
+
 = DESCRIPTION
 
 This (Moo) class/object represents a single process.
@@ -206,7 +212,7 @@ Depending on the OS, the following methods are available.  Also, all methods als
 
 Make no assumptions about what is available and what is not, not even {ppid}.  Instead, use the {has_*} methods and plan for alternatives
 if that data isn't available.
-   
+
 = CAVEATS
 
 * Certain fields might not be normalized correctly.  Patches welcome!

--- a/lib/P9Y/ProcessTable/VMS.pm
+++ b/lib/P9Y/ProcessTable/VMS.pm
@@ -6,7 +6,13 @@ package  # hide from PAUSE
 #############################################################################
 # Modules
 
-use sanity;
+# use sanity;
+use utf8;
+use strict qw(subs vars);
+no strict 'refs';
+use warnings FATAL => 'all';
+no warnings qw(uninitialized);
+
 use Moo;
 use P9Y::ProcessTable::Process;
 
@@ -20,7 +26,7 @@ no warnings 'uninitialized';
 
 sub table {
    my $self = shift;
-   return map { 
+   return map {
       my $hash = $self->_convert_hash($_);
       $hash->{_pt_obj} = $self;
       P9Y::ProcessTable::Process->new($hash);
@@ -54,9 +60,9 @@ sub _process_hash {
 sub _convert_hash {
    my ($self, $info) = @_;
    return unless $info;
-   
+
    my $hash = {};
-   state $stat_loc = { qw/
+   my $stat_loc = { qw/
       pid         PID
       uid         OWNER
       gid         GRP

--- a/lib/P9Y/ProcessTable/Win32.pm
+++ b/lib/P9Y/ProcessTable/Win32.pm
@@ -6,7 +6,13 @@ package  # hide from PAUSE
 #############################################################################
 # Modules
 
-use sanity;
+# use sanity;
+use utf8;
+use strict qw(subs vars);
+no strict 'refs';
+use warnings FATAL => 'all';
+no warnings qw(uninitialized);
+
 use Moo;
 use P9Y::ProcessTable::Process;
 
@@ -42,7 +48,7 @@ sub process {
    $pid = Win32::Process::GetCurrentProcessID if (@_ == 1);  # process() changed here...
    my $hash = $self->_process_hash($pid);
    return unless $hash && $hash->{pid} && $hash->{ppid};
-   
+
    $hash->{_pt_obj} = $self;
    return P9Y::ProcessTable::Process->new($hash);
 }
@@ -54,7 +60,7 @@ sub _process_hash {
    $info = $info->[0];
 
    my $hash = {};
-   state $stat_loc = { qw/
+   my $stat_loc = { qw/
       pid        ProcessId
       uid        Owner
       ppid       ParentProcessId
@@ -120,7 +126,7 @@ sub kill {
 
    # POSIX = 0 HUP INT QUIT ILL TRAP ABRT . FPE KILL . SEGV . PIPE ALRM TERM . . . . . . ABRT
    # 0x0010 = WM_CLOSE
-   state $posix2wm = [
+   my $posix2wm = [
       0, 0x0010, 0x0010, qw/kill kill kill kill . kill kill . kill ./, 0x0010, 0x0010, 0x0010, qw/. . . . . . kill/
    ];
 
@@ -150,7 +156,7 @@ sub kill {
 sub priority {
    my ($self, $pri) = @_;
    return $self->{priority} if @_ == 1;
-   
+
    $self->_win32_proc->SetPriorityClass($pri);
    $self->_set_priority($pri);
 }


### PR DESCRIPTION
I've made a few changes to replace 5.10.1 features with those that will work with 5.8.1.

`$work` is a mix of RHEL5 and Windows - an environment where P9Y::PT is very useful (and better than Proc::PT). However RHEL5 is still stuck on perl-5.8.8.
