### PR TITLE
remove utf8 pre-req

### DIFF
--- a/lib/P9Y/ProcessTable.pm
+++ b/lib/P9Y/ProcessTable.pm
@@ -4,7 +4,6 @@ package P9Y::ProcessTable;
 # ABSTRACT: Portably access the process table
 
 # use sanity;
-use utf8;
 use strict qw(subs vars);
 no strict 'refs';
 use warnings FATAL => 'all';

--- a/lib/P9Y/ProcessTable/BSD.pm
+++ b/lib/P9Y/ProcessTable/BSD.pm
@@ -7,7 +7,6 @@ package  # hide from PAUSE
 # Modules
 
 # use sanity;
-use utf8;
 use strict qw(subs vars);
 no strict 'refs';
 use warnings FATAL => 'all';

--- a/lib/P9Y/ProcessTable/Darwin.pm
+++ b/lib/P9Y/ProcessTable/Darwin.pm
@@ -7,7 +7,6 @@ package  # hide from PAUSE
 # Modules
 
 # use sanity;
-use utf8;
 use strict qw(subs vars);
 no strict 'refs';
 use warnings FATAL => 'all';

--- a/lib/P9Y/ProcessTable/OS2.pm
+++ b/lib/P9Y/ProcessTable/OS2.pm
@@ -7,7 +7,6 @@ package  # hide from PAUSE
 # Modules
 
 # use sanity;
-use utf8;
 use strict qw(subs vars);
 no strict 'refs';
 use warnings FATAL => 'all';

--- a/lib/P9Y/ProcessTable/ProcFS.pm
+++ b/lib/P9Y/ProcessTable/ProcFS.pm
@@ -7,7 +7,6 @@ package  # hide from PAUSE
 # Modules
 
 # use sanity;
-use utf8;
 use strict qw(subs vars);
 no strict 'refs';
 use warnings FATAL => 'all';

--- a/lib/P9Y/ProcessTable/Process.pm
+++ b/lib/P9Y/ProcessTable/Process.pm
@@ -7,7 +7,6 @@ package P9Y::ProcessTable::Process;
 # Modules
 
 # use sanity;
-use utf8;
 use strict qw(subs vars);
 no strict 'refs';
 use warnings FATAL => 'all';

--- a/lib/P9Y/ProcessTable/VMS.pm
+++ b/lib/P9Y/ProcessTable/VMS.pm
@@ -7,7 +7,6 @@ package  # hide from PAUSE
 # Modules
 
 # use sanity;
-use utf8;
 use strict qw(subs vars);
 no strict 'refs';
 use warnings FATAL => 'all';

--- a/lib/P9Y/ProcessTable/Win32.pm
+++ b/lib/P9Y/ProcessTable/Win32.pm
@@ -7,7 +7,6 @@ package  # hide from PAUSE
 # Modules
 
 # use sanity;
-use utf8;
 use strict qw(subs vars);
 no strict 'refs';
 use warnings FATAL => 'all';


### PR DESCRIPTION
Removed `use utf8;`.

This was previously added since it was used by `sanity`.
